### PR TITLE
bump @lwc/jest-resolver to a version that has jest default resolver fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@lwc/compiler": "0.34.4",
     "@lwc/engine": "0.34.4",
     "@lwc/jest-preset": "0.34.4",
-    "@lwc/jest-resolver": "0.34.4",
+    "@lwc/jest-resolver": "0.35.9",
     "@lwc/jest-serializer": "0.34.4",
     "@lwc/jest-transformer": "0.34.4",
     "@lwc/module-resolver": "0.34.4",


### PR DESCRIPTION
Ran into an error trying to run lwc-jest.
![image](https://user-images.githubusercontent.com/28264696/53273627-5aaa6480-36a9-11e9-86bb-75be5e91039f.png)

Updating the version of @lwc/jest-resolver to the latest fixed this.  