### PR TITLE
remove custom namespace logic in resolver

### DIFF
--- a/src/resolver.js
+++ b/src/resolver.js
@@ -13,7 +13,7 @@ const lwcResolver = require('@lwc/jest-resolver');
 const {
     PROJECT_ROOT,
     getModulePaths,
-    getNamespace,
+    DEFAULT_NAMESPACE,
 } = require('./utils/project.js');
 
 const {
@@ -60,13 +60,12 @@ function getLightningMock(modulePath) {
 
 function getModule(modulePath, options) {
     const { ns, name } = getInfoFromId(modulePath);
-    const projectNs = getNamespace();
 
     if (ns === 'lightning') {
         return getLightningMock(name);
     }
 
-    if (projectNs === ns) {
+    if (ns === DEFAULT_NAMESPACE) {
         const paths = getModulePaths();
         for (let i = 0; i < paths.length; i++) {
             const file = resolveAsFile(path.join(PROJECT_ROOT, paths[i], name, name), options.extensions);

--- a/src/utils/__mocks__/project.js
+++ b/src/utils/__mocks__/project.js
@@ -13,6 +13,5 @@ module.exports = {
     getSfdxProjectJson: () => {
         return { mock: true, sourceApiVersion: expectedApiVersion }
     },
-    getNamespace: 'mockedNamespace',
     getModulePaths: () => ['C:/WIN32/SYSTEM']
 };

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -43,13 +43,9 @@ function getModulePaths() {
     return paths;
 }
 
-function getNamespace() {
-    return getSfdxProjectJson().namespace || DEFAULT_NAMESPACE;
-}
-
 module.exports = {
     PROJECT_ROOT,
     getSfdxProjectJson,
-    getNamespace,
+    DEFAULT_NAMESPACE,
     getModulePaths,
 };


### PR DESCRIPTION
Locally in a Salesforce DX project, customers should reference their custom components with the `c` namespace. The custom namespace in `sfdx-project.json` should be ignored when trying to resolve these custom components in unit tests.