### PR TITLE
Ensure run with NODE_ENV set to test

### DIFF
--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -64,6 +64,10 @@ async function testRunner(argv) {
 
         shell.runCommand(command, commandArgs);
     } else {
+        // Jest will not set the env if not run from the bin executable
+        if (process.env.NODE_ENV == null) {
+            process.env.NODE_ENV = 'test';
+        }
         jestRunner.run([...config, ...options]);
     }
 }


### PR DESCRIPTION
To mimic the environment when the `jest` executable is invoked directly, set `process.env.NODE_ENV` to 'test' if not already set. 