### PR TITLE
add formatFractionDigits property to the mock

### DIFF
--- a/src/lightning-mocks/input/input.js
+++ b/src/lightning-mocks/input/input.js
@@ -20,6 +20,7 @@ export default class Input extends LightningElement {
 	@api disabled
 	@api files
 	@api formatter
+    @api formatFractionDigits
 	@api isLoading
 	@api label
 	@api max


### PR DESCRIPTION
this attribute (format-fraction-digits) already works fine in LWC so lets add it into mock file