### PR TITLE
remove api version check

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,9 +39,7 @@ const jestConfig = {
     ],
 };
 
-const expectedApiVersion = '45.0';
-
 // Execute command is different on Windows.
 const jestPath = process.platform == 'win32' ? './node_modules/jest/bin/jest.js' : 'node_modules/.bin/jest';
 
-module.exports = { jestConfig, jestPath,  expectedApiVersion };
+module.exports = { jestConfig, jestPath };

--- a/src/utils/__mocks__/project.js
+++ b/src/utils/__mocks__/project.js
@@ -6,12 +6,10 @@
  */
 'use strict';
 
-const { expectedApiVersion } = require('../../config');
-
 module.exports = {
     PROJECT_ROOT: 'projectRoot',
     getSfdxProjectJson: () => {
-        return { mock: true, sourceApiVersion: expectedApiVersion }
+        return { mock: true }
     },
     getModulePaths: () => ['C:/WIN32/SYSTEM']
 };

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -12,13 +12,11 @@ const { jestRunner } = require('./jest');
 const shell = require('./shell');
 
 const {
-    error,
     info,
 } = require('../log');
 
 const {
     PROJECT_ROOT,
-    getSfdxProjectJson,
 } = require('./project');
 
 const {

--- a/src/utils/test-runner.js
+++ b/src/utils/test-runner.js
@@ -23,7 +23,6 @@ const {
 
 const {
     jestConfig,
-    expectedApiVersion,
     jestPath
 } = require('../config');
 
@@ -42,12 +41,6 @@ function getOptions(argv) {
 }
 
 async function testRunner(argv) {
-    const sfdxProjectJson = getSfdxProjectJson();
-    const apiVersion = sfdxProjectJson.sourceApiVersion;
-    if (apiVersion !== expectedApiVersion) {
-        error(`Invalid sourceApiVersion found in sfdx-project.json. Expected ${expectedApiVersion}, found ${apiVersion}`);
-    }
-
     const hasCustomConfig = fs.existsSync(path.resolve(PROJECT_ROOT, 'jest.config.js'));
     const config = hasCustomConfig ? [] : ['--config', JSON.stringify(jestConfig)];
 


### PR DESCRIPTION
The API version check was originally put in place to ensure users were on the proper version of the testrunner that matched their Salesforce DX workspace. Since there's no logic in this package that is dependent on the API version, we can remove this check entirely.